### PR TITLE
Added functionality in regards to #14.

### DIFF
--- a/cmd/namegen/main.go
+++ b/cmd/namegen/main.go
@@ -15,9 +15,14 @@ func main() {
 	randomSeed := flag.Int64("s", 0, "Optional random generator seed")
 
 	mode := flag.String("m", "full", "Mode of generation")
+	var list = flag.Bool("l", false, "Print available name lists")
 
 	flag.Parse()
-
+	
+	if *list == true {
+		fmt.Print("Available name lists: \nenglish \nspanish \ngerman \nthai\n\n")
+	}
+	
 	if *randomSeed == 0 {
 		rand.Seed(time.Now().UnixNano())
 	} else {


### PR DESCRIPTION
Added basic functionality for when the `-l` flag is passed. The `l` flag is a boolean flag that, when true, will print the list of currently available language lists. 