### PR TITLE
Fix Panic When -o with Unsupported Origin

### DIFF
--- a/cmd/namegen/main.go
+++ b/cmd/namegen/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -59,19 +60,25 @@ func main() {
 	generator := namegen.NameGeneratorFromType(*origin, *gender)
 
 	output := ""
+	var err error
 	for i := 0; i < *numberOfNames; i++ {
 
 		switch *mode {
 		case "full":
-			output = generator.CompleteName(*gender)
+			output, err = generator.CompleteName(*gender)
 		case "firstname":
-			output = generator.FirstName(*gender)
+			output, err = generator.FirstName(*gender)
 		case "lastname":
-			output = generator.LastName()
+			output, err = generator.LastName()
 		default:
 			output = fmt.Sprintf("Unsupported generation mode %s, supported modes: full, firstname, lastname", *mode)
 		}
 
+		if err != nil && errors.Is(err, namegen.ErrorEmptyItems) {
+			output = fmt.Sprintf("Unsupported origin %s\nUse \"namegen -l\" to see supported origins", *origin)
+		}
+
 		fmt.Println(output)
 	}
+
 }

--- a/namegen.go
+++ b/namegen.go
@@ -38,12 +38,12 @@ func NameGeneratorFromType(origin, gender string) NameGenerator {
 }
 
 // LastName returns a last name
-func (gen NameGenerator) LastName() string {
+func (gen NameGenerator) LastName() (string, error) {
 	return RandomItem(gen.LastNames)
 }
 
 // FirstName returns a first name
-func (gen NameGenerator) FirstName(gender string) string {
+func (gen NameGenerator) FirstName(gender string) (string, error) {
 	firstNames := gen.MaleFirstNames
 	if gender == "female" {
 		firstNames = gen.FemaleFirstNames
@@ -55,6 +55,17 @@ func (gen NameGenerator) FirstName(gender string) string {
 }
 
 // CompleteName returns a complete name
-func (gen NameGenerator) CompleteName(gender string) string {
-	return gen.FirstName(gender) + " " + gen.LastName()
+func (gen NameGenerator) CompleteName(gender string) (string, error) {
+	firstName, err := gen.FirstName(gender)
+	if err != nil {
+		return "", err
+	}
+
+	lastName, err := gen.LastName()
+	if err != nil {
+		return "", err
+	}
+
+	fullname := firstName + " " + lastName
+	return fullname, nil
 }

--- a/random.go
+++ b/random.go
@@ -3,13 +3,23 @@ package namegen
 import (
 	"crypto/md5"
 	"encoding/binary"
+	"errors"
 	"io"
 	"math/rand"
 )
 
+var (
+	ErrorEmptyItems = errors.New("empty items")
+)
+
 // RandomItem returns a random string from an array of strings
-func RandomItem(items []string) string {
-	return items[rand.Intn(len(items))]
+func RandomItem(items []string) (string, error) {
+	itemsLen := len(items)
+	if itemsLen <= 0 {
+		return "", ErrorEmptyItems
+	}
+
+	return items[rand.Intn(itemsLen)], nil
 }
 
 // RandomItemFromThresholdMap returns a random weighted string


### PR DESCRIPTION
This PR prevent panic when flag -o used with unsupported origin.
It return error when items' length is 0 at [RandomItem](https://github.com/ironarachne/namegen/blob/feecf898f7b988b732f8af3c7c609855a7af8386/random.go#L11) function.

## Before
![image](https://user-images.githubusercontent.com/16364286/135727701-9fee4821-52eb-4b30-b7d9-ac089a5c1eb0.png)

## After
![image](https://user-images.githubusercontent.com/16364286/135727728-a98eaf6e-8794-4e85-bcfb-0be93f240af2.png)
