### PR TITLE
Fix names duplication at NameGeneratorFromType

### DIFF
--- a/namegen.go
+++ b/namegen.go
@@ -7,6 +7,19 @@ type NameGenerator struct {
 	LastNames        []string
 }
 
+func removeDuplicateNames(names []string) []string {
+	keys := make(map[string]bool)
+	list := []string{}
+
+	for _, entry := range names {
+		if _, value := keys[entry]; !value {
+			keys[entry] = true
+			list = append(list, entry)
+		}
+	}
+	return list
+}
+
 // NameGeneratorFromType sets up types of names
 func NameGeneratorFromType(origin, gender string) NameGenerator {
 	nameGenerators := map[string]NameGenerator{
@@ -34,7 +47,13 @@ func NameGeneratorFromType(origin, gender string) NameGenerator {
 		"thai":       {thaiMaleFirstNames, thaiFemaleFirstNames, thaiLastNames},
 	}
 
-	return nameGenerators[origin]
+	generatorByOrigin := nameGenerators[origin]
+	nameGenerator := NameGenerator{
+		MaleFirstNames:   removeDuplicateNames(generatorByOrigin.MaleFirstNames),
+		FemaleFirstNames: removeDuplicateNames(generatorByOrigin.FemaleFirstNames),
+		LastNames:        removeDuplicateNames(generatorByOrigin.LastNames),
+	}
+	return nameGenerator
 }
 
 // LastName returns a last name


### PR DESCRIPTION
To ensure that the names in list are truly individual, it is necessary to make each name unique.
It also improves accuracy when generating random data.

To prevent performance degradation, the duplication check is run once, when data has been collected but before randomization.
So it takes less resources on this process.